### PR TITLE
Update deprecated and clashing rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
 		'react/jsx-no-target-blank': 'error',
 		'react/jsx-no-undef': 'error',
 		'react/jsx-pascal-case': 'error',
-		'jsx-sort-props': ['error', {
+		'react/jsx-sort-props': ['error', {
 			callbacksLast: true,
 			shorthandFirst: true,
 			noSortAlphabetically: true
@@ -59,7 +59,7 @@ module.exports = {
 		'react/jsx-space-before-closing': ['error', 'never'],
 		'react/jsx-tag-spacing': ['error', {
 			closingSlash: 'never',
-			beforeSelfClosing: 'always',
+			beforeSelfClosing: 'never',
 			afterOpening: 'never'
 		}],
 		'react/jsx-uses-react': 'error',

--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,7 @@ test('space', t => {
 });
 
 test('no errors', t => {
-	const conf = require('../');
+	const conf = require('..');
 
 	const errors = runEslint('var React = require(\'react\');\nvar el = <div/>;', conf);
 	t.deepEqual(errors, []);

--- a/test/test.js
+++ b/test/test.js
@@ -33,3 +33,10 @@ test('space', t => {
 	const errors = runEslint('<App>\n\t<Hello/>\n</App>', conf);
 	t.true(hasRule(errors, 'react/jsx-indent'));
 });
+
+test('no errors', t => {
+	const conf = require('../');
+
+	const errors = runEslint('var React = require(\'react\');\nvar el = <div/>;', conf);
+	t.deepEqual(errors, []);
+});


### PR DESCRIPTION
closes #12 

-----

I was originally trying to fix the `Definition for rule jsx-sort-props was not found` issue, but after adding the test, I discovered two inconsistent rules: `react/jsx-space-before-closing` and `react/jsx-tag-spacing`

I hope you don't mind this PR includes 2 bug fixes