### PR TITLE
Update `eslint-plugin-react-hooks`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	],
 	"dependencies": {
 		"eslint-plugin-react": "^7.37.4",
-		"eslint-plugin-react-hooks": "^5.1.0"
+		"eslint-plugin-react-hooks": "^7.0.1"
 	},
 	"devDependencies": {
 		"ava": "^6.2.0",


### PR DESCRIPTION
Following the release of the [React Compiler](https://react.dev/learn/react-compiler), React’s official recommendations on [enforcing the Rules of React](https://react.dev/blog/2025/10/07/react-compiler-1#migrating-from-eslint-plugin-react-compiler-to-eslint-plugin-react-hooks) received a major update.  

This PR bumps `eslint-plugin-react-hooks` to [the latest version](https://react.dev/reference/eslint-plugin-react-hooks) aligned with those changes. The plugin remains backward compatible—it just introduces additional rules.

If agreed, I’d also like to include some of these new rules in XO’s config. The updated recommendations effectively iterate on what “writing proper React” means. And since XO is about great defaults, `eslint-config-xo-react` should follow suit.